### PR TITLE
Added triggers for submods, and added trigger for checking finished psionic paths

### DIFF
--- a/planetary_diversity/common/decisions/pd_cityworldreplaces.txt
+++ b/planetary_diversity/common/decisions/pd_cityworldreplaces.txt
@@ -85,7 +85,7 @@ decision_arcology_project = {
 					}
 				}
 				IF = {
-					limit = { owner = { has_origin = origin_pd_shroud has_tradition = tr_psionics_finish } }
+					limit = { owner = { has_origin = origin_pd_shroud pd_has_psionic_ascension_finished = yes } }
 					set_planet_entity = { picture = pc_shroudcity entity = pdshroudcity_planet_01_entity }
 					add_deposit = d_pd_shroud_arc
 				}
@@ -309,7 +309,7 @@ decision_arcology_project_relic = {
 				}
 			}
 			IF = {
-				limit = { owner = { has_origin = origin_pd_shroud has_tradition = tr_psionics_finish } }
+				limit = { owner = { has_origin = origin_pd_shroud pd_has_psionic_ascension_finished = yes } }
 				set_planet_entity = { picture = pc_shroudcity entity = pdshroudcity_planet_01_entity }
 				add_deposit = d_pd_shroud_arc
 			}

--- a/planetary_diversity/common/scripted_effects/pd_effects.txt
+++ b/planetary_diversity/common/scripted_effects/pd_effects.txt
@@ -44,7 +44,7 @@ pd_create_eco_arc_effect = {
 		set_planet_flag = pdaquapicture
 	}
 	IF = {
-		limit = { owner = { has_origin = origin_pd_shroud has_tradition = tr_psionics_finish  } }
+		limit = { owner = { has_origin = origin_pd_shroud pd_has_psionic_ascension_finished = yes  } }
 		set_planet_entity = { picture = pc_shroudcity entity = ecoshroud_planet_01_entity }
 		add_deposit = d_pd_shroud_arc
 	}
@@ -148,7 +148,7 @@ pd_create_mil_arc_effect = {
 		set_planet_flag = pdaquapicture
 	}
 	IF = {
-		limit = { owner = { has_origin = origin_pd_shroud has_tradition = tr_psionics_finish  } }
+		limit = { owner = { has_origin = origin_pd_shroud pd_has_psionic_ascension_finished = yes  } }
 		set_planet_entity = { picture = pc_shroudmilarc entity = milarcshroud_planet_01_entity }
 		add_deposit = d_pd_shroud_arc
 	}
@@ -214,7 +214,7 @@ pd_create_corpo_arc_effect = {
 		set_planet_flag = pdaquapicture
 	}
 	IF = {
-		limit = { owner = { has_origin = origin_pd_shroud has_tradition = tr_psionics_finish } }
+		limit = { owner = { has_origin = origin_pd_shroud pd_has_psionic_ascension_finished = yes } }
 		set_planet_entity = { picture = pc_shroudcorpoarc entity = pdshroudcity_planet_01_entity }
 		add_deposit = d_pd_shroud_arc
 	}

--- a/planetary_diversity/common/scripted_triggers/00_pd_scripted_triggers_compat.txt
+++ b/planetary_diversity/common/scripted_triggers/00_pd_scripted_triggers_compat.txt
@@ -8,4 +8,12 @@ is_acot_unique_planet_class = {
 	always = no
 }
 
+######################
+### Other Triggers ###
+######################
 
+pd_has_psionic_ascension_finished = {
+	OR = {
+		has_tradition = tr_psionics_finish
+	}
+}

--- a/planetary_diversity/events/pd_engine.txt
+++ b/planetary_diversity/events/pd_engine.txt
@@ -7719,7 +7719,7 @@ planet_event = {
 		limit = { 
 			has_deposit = d_pd_shroud_arc
 			OR = {
-				NOT = { owner = { has_tradition = tr_psionics_finish  } }
+				NOT = { owner = { pd_has_psionic_ascension_finished = yes  } }
 				NOT = { owner = { has_origin =  origin_pd_shroud } }
 			}
 		}

--- a/planetary_diversity_arcologies/common/decisions/pd_arc_decisions.txt
+++ b/planetary_diversity_arcologies/common/decisions/pd_arc_decisions.txt
@@ -1181,9 +1181,7 @@ decision_pd_shroud_arc_spot = {
 		}
 		exists = owner
 		owner = {
-			OR = {
-				has_tradition = tr_psionics_finish 
-			}
+			pd_has_psionic_ascension_finished = yes
 		}
 		NOT = { has_deposit = d_pd_necro_arc }
 		NOT = { has_deposit = d_pd_shroud_arc }
@@ -1241,9 +1239,7 @@ decision_pd_shroud_arc = {
 		}
 		exists = owner
 		owner = {
-			OR = {
-				has_tradition = tr_psionics_finish 
-			}
+			pd_has_psionic_ascension_finished = yes
 		}
 		NOT = { has_deposit = d_pd_necro_arc }
 		NOT = { has_deposit = d_pd_shroud_arc }
@@ -1354,7 +1350,7 @@ decision_remove_shroud_arc = {
 			is_planet_class = pc_corpoarc
 		}
 		exists = owner
-		NOT = { owner = { has_tradition = tr_psionics_finish  } }
+		owner = { pd_has_psionic_ascension_finished = no }
 		has_deposit = d_pd_shroud_arc
 	}
 	

--- a/planetary_diversity_arcologies/common/scripted_triggers/pd_arcologies_scripted_triggers.txt
+++ b/planetary_diversity_arcologies/common/scripted_triggers/pd_arcologies_scripted_triggers.txt
@@ -1,0 +1,1 @@
+has_planetary_diversity_arcologies = { always = yes }

--- a/planetary_diversity_exotics/common/scripted_triggers/pd_exotics_scripted_triggers.txt
+++ b/planetary_diversity_exotics/common/scripted_triggers/pd_exotics_scripted_triggers.txt
@@ -1,0 +1,1 @@
+has_planetary_diversity_exotics = { always = yes }

--- a/planetary_diversity_planetaryhabitats/common/scripted_triggers/pd_planetaryhabitats_scripted_triggers.txt
+++ b/planetary_diversity_planetaryhabitats/common/scripted_triggers/pd_planetaryhabitats_scripted_triggers.txt
@@ -1,0 +1,1 @@
+has_planetary_diversity_planetaryhabitats = { always = yes }

--- a/planetary_diversity_shroud/common/decisions/pd_shroud_decisions.txt
+++ b/planetary_diversity_shroud/common/decisions/pd_shroud_decisions.txt
@@ -117,7 +117,7 @@ decision_unshroud_world = {
 #	}
 #	
 #	potential = {
-#		owner = { has_tradition = tr_psionics_finish  }
+#		owner = { pd_has_psionic_ascension_finished = yes  }
 #		is_artificial = no
 #		is_pd_habitat = no
 #		is_pd_planetary_megaproject = no
@@ -182,7 +182,7 @@ decision_shroud_to_shroud_arc = {
 		exists = owner
 		owner = { 
 			has_ascension_perk = ap_arcology_project 
-			has_tradition = tr_psionics_finish 
+			pd_has_psionic_ascension_finished = yes 
 		}
 	}
 	
@@ -263,7 +263,7 @@ decision_shroud_to_shroudecoarcology_project = {
 		exists = owner
 		owner = { 
 			has_ascension_perk = ap_arcology_project 
-			has_tradition = tr_psionics_finish 
+			pd_has_psionic_ascension_finished = yes 
 		}
 	}
 	
@@ -340,7 +340,7 @@ decision_shroud_to_shroudmilarcology_project = {
 		exists = owner
 		owner = { 
 			has_ascension_perk = ap_arcology_project 
-			has_tradition = tr_psionics_finish 
+			pd_has_psionic_ascension_finished = yes 
 		}
 	}
 	
@@ -422,7 +422,7 @@ decision_shroud_to_shroudcorpoarcology_project = {
 		exists = owner
 		owner = { 
 			has_ascension_perk = ap_arcology_project 
-			has_tradition = tr_psionics_finish 
+			pd_has_psionic_ascension_finished = yes 
 		}
 		free_district_slots >= 6
 		owner = { is_megacorp = yes }

--- a/planetary_diversity_shroud/common/scripted_triggers/pd_shroud_scripted_triggers.txt
+++ b/planetary_diversity_shroud/common/scripted_triggers/pd_shroud_scripted_triggers.txt
@@ -1,0 +1,1 @@
+has_planetary_diversity_shroud = { always = yes }

--- a/planetary_diversity_shroud/common/terraform/pd_shroud_terraform_links.txt
+++ b/planetary_diversity_shroud/common/terraform/pd_shroud_terraform_links.txt
@@ -92,8 +92,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
 terraform_link = {
@@ -101,8 +101,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -111,8 +111,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -121,8 +121,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -131,8 +131,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -141,8 +141,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -151,8 +151,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -161,8 +161,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { from = { has_modifier = terraforming_candidate } has_tradition = tr_psionics_finish   }
-	condition = { has_technology = "tech_climate_restoration" has_tradition = tr_psionics_finish   }
+	potential = { from = { has_modifier = terraforming_candidate } pd_has_psionic_ascension_finished = yes   }
+	condition = { has_technology = "tech_climate_restoration" pd_has_psionic_ascension_finished = yes   }
 	effect = { from = { remove_modifier = terraforming_candidate } }
 	ai_weight = { weight = 5 }
 }
@@ -171,8 +171,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { from = { has_modifier = terraforming_candidate } has_tradition = tr_psionics_finish   }
-	condition = { has_technology = "tech_climate_restoration" has_tradition = tr_psionics_finish   }
+	potential = { from = { has_modifier = terraforming_candidate } pd_has_psionic_ascension_finished = yes   }
+	condition = { has_technology = "tech_climate_restoration" pd_has_psionic_ascension_finished = yes   }
 	effect = { from = { remove_modifier = terraforming_candidate } }
 	ai_weight = { weight = 5 }
 }
@@ -181,8 +181,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -191,8 +191,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -201,8 +201,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -211,8 +211,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -221,8 +221,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -231,8 +231,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -241,8 +241,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -251,8 +251,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -261,8 +261,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -271,8 +271,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -281,8 +281,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -291,8 +291,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -301,8 +301,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -311,8 +311,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -321,8 +321,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = 360
-	potential = { from = { has_modifier = terraforming_candidate } has_tradition = tr_psionics_finish   }
-	condition = { has_technology = "tech_climate_restoration" has_tradition = tr_psionics_finish   }
+	potential = { from = { has_modifier = terraforming_candidate } pd_has_psionic_ascension_finished = yes   }
+	condition = { has_technology = "tech_climate_restoration" pd_has_psionic_ascension_finished = yes   }
 	effect = { from = { remove_modifier = terraforming_candidate } }
 	ai_weight = { weight = 5 }
 }
@@ -339,8 +339,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { from = { has_modifier = terraforming_candidate } has_tradition = tr_psionics_finish   }
-	condition = { has_technology = "tech_climate_restoration" has_tradition = tr_psionics_finish   }
+	potential = { from = { has_modifier = terraforming_candidate } pd_has_psionic_ascension_finished = yes   }
+	condition = { has_technology = "tech_climate_restoration" pd_has_psionic_ascension_finished = yes   }
 	effect = { from = { remove_modifier = terraforming_candidate } }
 	ai_weight = { weight = 5 }
 }
@@ -349,8 +349,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -359,8 +359,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -369,8 +369,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -379,8 +379,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  } 
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  } 
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -389,8 +389,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -399,8 +399,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -409,8 +409,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -419,8 +419,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -429,8 +429,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -439,8 +439,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -449,8 +449,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -459,8 +459,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -469,8 +469,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -479,8 +479,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -489,8 +489,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -499,8 +499,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -509,8 +509,8 @@ terraform_link = {
 	to = pc_pdshroud_cave
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -519,8 +519,8 @@ terraform_link = {
 	to = pc_pdshroud_superhab
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -529,8 +529,8 @@ terraform_link = {
 	to = pc_tidallyshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -539,8 +539,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -549,8 +549,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -559,8 +559,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -569,8 +569,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -579,8 +579,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -589,8 +589,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -599,8 +599,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }	 
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }	 
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -609,8 +609,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -619,8 +619,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -629,8 +629,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_tradition = tr_psionics_finish  }
-	potential = { has_tradition = tr_psionics_finish  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -641,8 +641,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_technology = "tech_climate_restoration" has_tradition = tr_psionics_finish  }
-	potential = { has_technology = "tech_climate_restoration" has_tradition = tr_psionics_finish  }
+	condition = { has_technology = "tech_climate_restoration" pd_has_psionic_ascension_finished = yes  }
+	potential = { has_technology = "tech_climate_restoration" pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 	effect = { from = { clear_deposits = yes clear_planet_modifiers = yes reroll_planet = yes } }
 }
@@ -651,8 +651,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	condition = { has_technology = "tech_climate_restoration" has_tradition = tr_psionics_finish  }
-	potential = { has_technology = "tech_climate_restoration" has_tradition = tr_psionics_finish  }
+	condition = { has_technology = "tech_climate_restoration" pd_has_psionic_ascension_finished = yes  }
+	potential = { has_technology = "tech_climate_restoration" pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 
 }
@@ -663,8 +663,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -673,8 +673,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -683,8 +683,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -693,8 +693,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -703,8 +703,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = geothermal } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -713,8 +713,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = biolumen } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -723,8 +723,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = pdsalt } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -733,8 +733,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = pdaquifer } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -743,8 +743,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = pdaquifer } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -753,8 +753,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = pdcoral } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -763,8 +763,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = geothermal } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -773,8 +773,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = geothermal } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -783,8 +783,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = geothermal } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -793,8 +793,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = geothermal } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -804,8 +804,8 @@ terraform_link = {
 	to = pc_tidallyshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { from = { has_modifier = terraforming_candidate } has_tradition = tr_psionics_finish   }
-	condition = { has_technology = "tech_climate_restoration" has_tradition = tr_psionics_finish   }
+	potential = { from = { has_modifier = terraforming_candidate } pd_has_psionic_ascension_finished = yes   }
+	condition = { has_technology = "tech_climate_restoration" pd_has_psionic_ascension_finished = yes   }
 	effect = { from = { remove_modifier = terraforming_candidate } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -814,8 +814,8 @@ terraform_link = {
 	to = pc_tidallyshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = tidal_locked2 } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -824,8 +824,8 @@ terraform_link = {
 	to = pc_tidallyshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = wettidallylocked } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -834,8 +834,8 @@ terraform_link = {
 	to = pc_tidallyshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -844,8 +844,8 @@ terraform_link = {
 	to = pc_tidallyshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -854,8 +854,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = pdsinkhole } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -864,8 +864,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = pdstorm } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -874,8 +874,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = pdiceberg } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -884,8 +884,8 @@ terraform_link = {
 	to = pc_tidallyshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = pdeyeball } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -894,8 +894,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = pdglacio } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -904,8 +904,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = pdlanthanide } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -914,8 +914,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = pdrogue } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -924,8 +924,8 @@ terraform_link = {
 	to = pc_pdshroud
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	effect = { from = { remove_modifier = pdlichen } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -935,8 +935,8 @@ terraform_link = {
 	to = pc_pdshroud_superhab
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { from = { has_modifier = terraforming_candidate } has_tradition = tr_psionics_finish   }
-	condition = { has_technology = "tech_climate_restoration" has_tradition = tr_psionics_finish   }
+	potential = { from = { has_modifier = terraforming_candidate } pd_has_psionic_ascension_finished = yes   }
+	condition = { has_technology = "tech_climate_restoration" pd_has_psionic_ascension_finished = yes   }
 	effect = { from = { remove_modifier = terraforming_candidate } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -945,8 +945,8 @@ terraform_link = {
 	to = pc_pdshroud_superhab
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
 terraform_link = {
@@ -954,8 +954,8 @@ terraform_link = {
 	to = pc_pdshroud_superhab
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
 terraform_link = {
@@ -963,8 +963,8 @@ terraform_link = {
 	to = pc_pdshroud_superhab
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
 terraform_link = {
@@ -972,8 +972,8 @@ terraform_link = {
 	to = pc_pdshroud_superhab
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
 terraform_link = {
@@ -981,8 +981,8 @@ terraform_link = {
 	to = pc_pdshroud_superhab
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
 #Cave
@@ -991,8 +991,8 @@ terraform_link = {
 	to = pc_pdshroud_cave
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { from = { has_modifier = terraforming_candidate } has_tradition = tr_psionics_finish   }
-	condition = { has_technology = "tech_climate_restoration" has_tradition = tr_psionics_finish   }
+	potential = { from = { has_modifier = terraforming_candidate } pd_has_psionic_ascension_finished = yes   }
+	condition = { has_technology = "tech_climate_restoration" pd_has_psionic_ascension_finished = yes   }
 	effect = { from = { remove_modifier = terraforming_candidate } }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
@@ -1001,8 +1001,8 @@ terraform_link = {
 	to = pc_pdshroud_cave
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
 terraform_link = {
@@ -1010,8 +1010,8 @@ terraform_link = {
 	to = pc_pdshroud_cave
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
 terraform_link = {
@@ -1019,8 +1019,8 @@ terraform_link = {
 	to = pc_pdshroud_cave
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
 terraform_link = {
@@ -1028,8 +1028,8 @@ terraform_link = {
 	to = pc_pdshroud_cave
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }
 terraform_link = {
@@ -1037,7 +1037,7 @@ terraform_link = {
 	to = pc_pdshroud_cave
     resources = { category = terraforming cost = { sr_zro = @terraforming_cost_shroud } }
 	duration = @terraforming_durantion_shroud
-	potential = { has_tradition = tr_psionics_finish  }
-	condition = { has_tradition = tr_psionics_finish  }
+	potential = { pd_has_psionic_ascension_finished = yes  }
+	condition = { pd_has_psionic_ascension_finished = yes  }
 	ai_weight = { weight = 1 modifier = { factor = 0 NOT = { has_origin = origin_pd_shroud } } modifier = { factor = 0 resource_stockpile_compare = { resource = sr_zro value < 500 } } }
 }

--- a/planetary_diversity_shroud/events/pd_shroud_events.txt
+++ b/planetary_diversity_shroud/events/pd_shroud_events.txt
@@ -61,7 +61,7 @@ ship_event = {
 			NOT = { 
 				OR = {
 					owner = { has_ascension_perk = ap_mind_over_matter } 
-					owner = { has_tradition = tr_psionics_finish  } 
+					owner = { pd_has_psionic_ascension_finished = yes  } 
 				}
 			}
 		}
@@ -75,7 +75,7 @@ ship_event = {
 	desc = {
 		text = pdshroud.10.desc.tra
 		trigger = { 
-			owner = { has_tradition = tr_psionics_finish  } 
+			owner = { pd_has_psionic_ascension_finished = yes  } 
 		}
 	}
 
@@ -359,7 +359,7 @@ ship_event = {
 			NOT = { 
 				OR = {
 					owner = { has_ascension_perk = ap_mind_over_matter } 
-					owner = { has_tradition = tr_psionics_finish  } 
+					owner = { pd_has_psionic_ascension_finished = yes  } 
 				}
 			}
 		}
@@ -373,7 +373,7 @@ ship_event = {
 	desc = {
 		text = pdshroud.20.desc.tra
 		trigger = { 
-			owner = { has_tradition = tr_psionics_finish  } 
+			owner = { pd_has_psionic_ascension_finished = yes  } 
 		}
 	}
 
@@ -662,7 +662,7 @@ ship_event = {
 			NOT = { 
 				OR = {
 					owner = { has_ascension_perk = ap_mind_over_matter } 
-					owner = { has_tradition = tr_psionics_finish } 
+					owner = { pd_has_psionic_ascension_finished = yes } 
 				}
 			}
 		}
@@ -676,7 +676,7 @@ ship_event = {
 	desc = {
 		text = pdshroud.30.desc.tra
 		trigger = { 
-			owner = { has_tradition = tr_psionics_finish  } 
+			owner = { pd_has_psionic_ascension_finished = yes  } 
 		}
 	}
 
@@ -916,7 +916,7 @@ ship_event = {
 			NOT = { 
 				OR = {
 					owner = { has_ascension_perk = ap_mind_over_matter } 
-					owner = { has_tradition = tr_psionics_finish } 
+					owner = { pd_has_psionic_ascension_finished = yes } 
 				}
 			}
 		}
@@ -930,7 +930,7 @@ ship_event = {
 	desc = {
 		text = pdshroud.40.desc.tra
 		trigger = { 
-			owner = { has_tradition = tr_psionics_finish  } 
+			owner = { pd_has_psionic_ascension_finished = yes  } 
 		}
 	}
 

--- a/planetary_diversity_uniques/common/scripted_triggers/pd_uniques_scripted_triggers.txt
+++ b/planetary_diversity_uniques/common/scripted_triggers/pd_uniques_scripted_triggers.txt
@@ -1,0 +1,1 @@
+has_planetary_diversity_uniques = { always = yes }


### PR DESCRIPTION
This PR adds some compatibility triggers that can be easily overwritten for other mods/merger of rules to add support for PD shroud mechanics, mainly checking for psionic tradition finished. Also providing triggers for checking the presence of submods (mod flag is still set, but the trigger would help in case submods are removed mid play)