### PR TITLE
fixing humanoid ringworld entity names

### DIFF
--- a/planetary_diversity/gfx/models/planets/_pd_ammonia_ring.asset
+++ b/planetary_diversity/gfx/models/planets/_pd_ammonia_ring.asset
@@ -2,7 +2,7 @@
 
 # ammonia ring - humanoid
 entity = {
-	name = "ammoniaring_habitable_entity_01_entity"
+	name = "humanoid_01_ammoniaring_habitable_entity_01_entity"
 	cull_radius = 500.0
 	pdxmesh = "ringworld_habitable_01_mesh"
 

--- a/planetary_diversity/gfx/models/planets/_pd_aquatic_ring.asset
+++ b/planetary_diversity/gfx/models/planets/_pd_aquatic_ring.asset
@@ -394,7 +394,7 @@ entity = {
 
 # aquatic ring (PD) - humanoid
 entity = {
-	name = "pdaquatic_01_ringworld_habitable_entity_01_entity"
+	name = "humanoid_01_pdaquatic_ringworld_habitable_entity_01_entity"
 	cull_radius = 500.0
 	pdxmesh = "ringworld_habitable_01_mesh"
 

--- a/planetary_diversity/gfx/models/planets/_pd_ash_ring.asset
+++ b/planetary_diversity/gfx/models/planets/_pd_ash_ring.asset
@@ -2,7 +2,7 @@
 
 # ash ring - humanoid
 entity = {
-	name = "ashring_habitable_entity_01_entity"
+	name = "humanoid_01_ashring_habitable_entity_01_entity"
 	cull_radius = 500.0
 	pdxmesh = "ringworld_habitable_01_mesh"
 

--- a/planetary_diversity/gfx/models/planets/_pd_hycean_ring.asset
+++ b/planetary_diversity/gfx/models/planets/_pd_hycean_ring.asset
@@ -396,7 +396,7 @@ entity = {
 
 # hycean ring - humanoid
 entity = {
-	name = "hycean_01_ringworld_habitable_entity_01_entity"
+	name = "humanoid_01_hycean_ringworld_habitable_entity_01_entity"
 	cull_radius = 500.0
 	pdxmesh = "ringworld_habitable_01_mesh"
 
@@ -415,15 +415,7 @@ entity = {
         shader = "PdxMeshTerra"
     }
 
-	meshsettings = {
-        name = "pCube20Shape"
-        index = 0
-        texture_diffuse = "ringworld_habitable_diffuse.dds"
-        texture_normal = "ringworld_habitable_normal.dds"
-        texture_specular = "ringworld_habitable_specular.dds"
-        shader = "PdxMeshTerra"
-    }
-
+	
 	meshsettings = {
 		name = "polySurface9Shape"
 		index = 0

--- a/planetary_diversity/gfx/models/planets/_pd_methane_ring.asset
+++ b/planetary_diversity/gfx/models/planets/_pd_methane_ring.asset
@@ -2,7 +2,7 @@
 
 # methane ring - humanoid
 entity = {
-	name = "methanering_habitable_entity_01_entity"
+	name = "humanoid_01_methanering_habitable_entity_01_entity"
 	cull_radius = 500.0
 	pdxmesh = "ringworld_habitable_01_mesh"
 

--- a/planetary_diversity/gfx/models/planets/_pd_sulfur_ring.asset
+++ b/planetary_diversity/gfx/models/planets/_pd_sulfur_ring.asset
@@ -2,7 +2,7 @@
 
 # sulfur ring - humanoid
 entity = {
-	name = "sulfurring_habitable_entity_01_entity"
+	name = "humanoid_01_sulfurring_habitable_entity_01_entity"
 	cull_radius = 500.0
 	pdxmesh = "ringworld_habitable_01_mesh"
 


### PR DESCRIPTION
I must apologise for that. I made a mistake when creating humanoid ringworlds. 
As base-game humanoid ringworlds always use same entities of prest fallen empire ringworlds, I thought it's ok if I don't put "humanoid_01" prefix in exotic ringworld entity names. But furthur tests shows this doesn't work.
Now I have to rename them.
Also, Gatekeeper, you have set wrong entity names to entity names of flooded and hycean rings of humanoid. There is "pdaquatic_01" and "hycean_01", not "pdaquatic" and "hycean". But I didn't check it out before, and I have a part to play.